### PR TITLE
chore: modernize PR checklist for mixed-stack, agent-era workflow

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -9,18 +9,15 @@
 - @co-author (if applicable)
 
 ### ✅ Checklist
-- [ ] Confluence documentation linked in PR
-- [ ] Relevant documentation is updated (README, Confluence, etc.).
-- [ ] Linting has been applied (`flake8`, `black`, etc.).
-- [ ] Docstrings are present for all functions and files.
-- [ ] Type hints are used for all functions.
-- [ ] Line comments are used within reason and where necessary.
-- [ ] You are using the correct naming conventions for functions and variables.
-- [ ] Example configuration files are provided (if relevant).
-- [ ] Your requirements.txt file contains fixed versions.
-- [ ] No keys or passwords pushed.
-- [ ] Large/unneeded/personal files are added to gitignore.
-- [ ] This PR has been tested and reviewed before submission.
+- [ ] I have self-reviewed every line of this diff (including AI-generated code).
+- [ ] Tests are added or updated for the changes (or N/A — explain in Notes).
+- [ ] CI is green (lint, type-check, tests).
+- [ ] Documentation is updated where relevant (README, Confluence — link it above).
+- [ ] Breaking changes, DB migrations, and new env vars are called out (`.env.example` / sample configs updated).
+- [ ] No secrets committed (keys, tokens, passwords, connection strings).
+- [ ] No large, generated, or personal files committed (gitignore updated if needed).
+- [ ] UI changes include screenshots or a short recording.
+- [ ] This PR covers one concern; unrelated changes are split out.
 
 ### 🛠 How to Test
 <!-- If relevant, describe the testing steps and how reviewers can verify the changes. -->


### PR DESCRIPTION
### 📌 Pull Request Summary
The PR checklist dated from the Python era and duplicated what CI now enforces. This replaces it with 9 stack-agnostic, human-verifiable items focused on author judgment — especially relevant now that agents author most PRs.

### 🔍 Changes in This PR
- Removed CI-redundant items: linting applied, type hints, naming conventions (enforced by lint/type-check workflows).
- Removed Python-only items: `flake8`/`black`, `requirements.txt` fixed versions.
- Removed unverifiable items: "line comments within reason", "docstrings for all functions".
- Merged the two overlapping documentation items into one.
- Added: self-review of every diff line (incl. AI-generated code), tests added/updated, CI green, breaking changes/migrations/env vars called out, screenshots for UI changes, single-concern scope.
- Broadened "no keys or passwords" to all secret types.

### 👤 Contributors
- @lucasvandijck (Main Contributor)

### ✅ Checklist
- [x] I have self-reviewed every line of this diff (including AI-generated code).
- [ ] Tests are added or updated for the changes (or N/A — explain in Notes).
- [ ] CI is green (lint, type-check, tests).
- [x] Documentation is updated where relevant (README, Confluence — link it above).
- [ ] Breaking changes, DB migrations, and new env vars are called out (`.env.example` / sample configs updated).
- [x] No secrets committed (keys, tokens, passwords, connection strings).
- [x] No large, generated, or personal files committed (gitignore updated if needed).
- [ ] UI changes include screenshots or a short recording.
- [x] This PR covers one concern; unrelated changes are split out.

### 🛠 How to Test
Open a draft PR in any org repo without its own template and confirm the new checklist renders.

### 📝 Additional Notes
Tests/CI/migrations/UI items: N/A — markdown-only change in a config repo with no CI.

### 🔗 Related Issues/Tickets
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)